### PR TITLE
add argparse commands for custom os.environ

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,14 @@ the defaults work with the <a href='https://github.com/candidelabs/CandideWallet
 python manage.py createsuperuser
 ```
 
-### Run the server
+### Run the server with default os.environ
 ```
 python manage.py runserver
+```
+
+### Run the server with a custom os.environ
+```
+python3 manage.py runserver --port 1337 --chainId 10 --HTTPProvider http://localhost:8545
 ```
 
 ### Access the control panel

--- a/bundler/bundler.py
+++ b/bundler/bundler.py
@@ -110,7 +110,7 @@ def deployModuleManager(salt) -> bool:
     gasFees = getGasFees()
 
     txnDict = {
-            "chainId": 5,
+            "chainId": env('chainId'),
             "from": env('bundler_pub'),
             "nonce": w3.eth.get_transaction_count(env('bundler_pub')),
             'gas': 4800000
@@ -186,7 +186,7 @@ def eth_sendUserOperation(request) -> Result:
     gasFees = getGasFees()
 
     txnDict = {
-            "chainId": 5,
+            "chainId": env('chainId'),
             "from": env('bundler_pub'),
             "nonce": w3.eth.get_transaction_count(env('bundler_pub')),
             'gas': math.ceil(gasEstimation),

--- a/manage.py
+++ b/manage.py
@@ -3,9 +3,27 @@
 import os
 import sys
 
+import argparse
 
 def main():
     """Run administrative tasks."""
+    parser = argparse.ArgumentParser(description='Overwrite values in os.environ with optional command-line arguments')
+    parser.add_argument('--port', help='port number', type=int)
+    parser.add_argument('--chainId', help='The Ethereum Network chain ID', type=int)
+    parser.add_argument('--HTTPProvider', help='The Ethereum Network URL HTTP provider', type=str)
+    args, remaining_argv = parser.parse_known_args()
+
+    if args.chainId:
+        os.environ["chainId"] = str(args.chainId)
+    if args.HTTPProvider:
+        os.environ["HTTPProvider"] = args.HTTPProvider
+    if args.port:
+        os.environ["PORT"] = str(args.port)
+    
+    if 'runserver' in remaining_argv:
+        if args.port:
+            remaining_argv += ['0.0.0.0:{}'.format(args.port)]
+
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "bundler.settings")
     try:
         from django.core.management import execute_from_command_line
@@ -15,8 +33,7 @@ def main():
             "available on your PYTHONPATH environment variable? Did you "
             "forget to activate a virtual environment?"
         ) from exc
-    execute_from_command_line(sys.argv)
-
+    execute_from_command_line(['manage.py'] + remaining_argv)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Example:

default os: ```python manage.py runserver```

custom: ```python3 manage.py runserver --port 1337 --chainId 10 --HTTPProvider http://localhost:8545```